### PR TITLE
Support the module attribute

### DIFF
--- a/vue-mode.el
+++ b/vue-mode.el
@@ -95,6 +95,7 @@
           " +lang=\"%s\""              ; The language specifier
           "\\(?: +\\w+=\".*?\" *?\\)*" ; More optional key-value pairs
           "\\(?: +scoped\\)?"          ; The optional "scoped" attribute
+          "\\(?: +module\\)?"          ; The optional "module" attribute
           " *>\n")                     ; The end of the tag
   "A regular expression for the starting tags of template areas with languages.
 To be formatted with the tag name, and the language.")
@@ -104,6 +105,7 @@ To be formatted with the tag name, and the language.")
           "\\(?: +" vue--not-lang-key "\".*?\" *?\\)*" ; Any optional key-value pairs like type="foo/bar".
           ;; ^ Disallow "lang" in k/v pairs to avoid matching regions with non-default languages
           "\\(?: +scoped\\)?"          ; The optional "scoped" attribute
+          "\\(?: +module\\)?"          ; The optional "module" attribute
           " *>\n")                     ; The end of the tag
   "A regular expression for the starting tags of template areas.
 To be formatted with the tag name.")


### PR DESCRIPTION
This allows [css modules][1], e.g. `<style module>`.

[1]: https://github.com/vuejs/vue-loader/blob/master/docs/en/features/css-modules.md