### PR TITLE
Adds support for <script setup> for #117 when lang is not specified, complements #115

### DIFF
--- a/test/vue-mode-test.el
+++ b/test/vue-mode-test.el
@@ -66,6 +66,7 @@
   '(;; Bare tags
     "<style>\n"
     "<script>\n"
+    "<script setup>\n"
     "<template>\n"
     "<style scoped>\n"
     ;; Arbitrary k/v

--- a/vue-mode.el
+++ b/vue-mode.el
@@ -157,6 +157,7 @@ To be formatted with the tag name, and the language.")
           ;; ^ Disallow "lang" in k/v pairs to avoid matching regions with non-default languages
           "\\|\\(?:\\s-+scoped\\)"      ; The optional "scoped" attribute
           "\\|\\(?:\\s-+module\\)"      ; The optional "module" attribute
+          "\\|\\(?:\\s-+setup\\)"       ; The optional "setup" attribute
           "\\)*"
           "\\s-*>\n")                     ; The end of the tag
   "A regular expression for the starting tags of template areas.


### PR DESCRIPTION
For #117 when lang is not specified

#115 fixes the case where `lang=` is specified. This pull request fixes the case where `lang` is not added e.g. `<script setup>`



